### PR TITLE
Updated dependencies in meta.yaml to v2.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "Werkzeug" %}
-{% set version = "1.0.1" %}
+{% set version = "2.0.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c
+  sha256: 1de1db30d010ff1af14a009224ec49ab2329ad2cde454c8a708130642d579c42
 
 build:
   noarch: python
@@ -16,19 +16,24 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.6
     - pip
   run:
-    - python
+    - python >=3.6
+    - dataclasses
 
 test:
+  requires:
+    - pip
   imports:
     - werkzeug
     - werkzeug.debug
+  commands:
+    - pip check
 
 about:
   home: https://palletsprojects.com/p/werkzeug/
-  license: BSD 3-Clause
+  license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.rst
   summary: The comprehensive WSGI web application library.


### PR DESCRIPTION
<!--
Please add any other relevant info below:
-->

It's a dependency of packages:
airflow
flask
flask-appbuilder
flask-caching
flask-jwt-extended
flask-restx
flask-wtf
moto
pytest-localserver
sendgrid
tensorboard
tranquilizer
werkzeug

----------------------------
Category:  anaconda
Popularity: high, 2,878,835 downloads
Branch: v2.0.1
Version change: bump version number from 1.0.1 to v2.0.1
Update branch: https://github.com/AnacondaRecipes/werkzeug-feedstock/blob/v2.0.1/recipe/meta.yaml
license: BSD 3-Clause
Release date: May, 18, 2021, https://pypi.org/project/werkzeug/#history
Changelog: breaking changes https://werkzeug.palletsprojects.com/en/2.0.x/changes/#version-2-0-1
dev_url:  https://github.com/pallets/werkzeug
Bug Tracker: new open issues https://github.com/pallets/werkzeug/issues
Github releases:  https://github.com/pallets/werkzeug/releases
Github license:  https://github.com/pallets/werkzeug/blob/main/LICENSE.rst
Upstream setup.cfg:  https://github.com/pallets/werkzeug/blob/main/setup.cfg
Upstream setup.py:  https://github.com/pallets/werkzeug/blob/main/setup.py
Concourse builds correctly

Actions:
1. Updated dependencies in meta.yaml from upstream source

Result:
- all-succeeded