### PR TITLE
Updated to 2.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "Werkzeug" %}
-{% set version = "1.0.1" %}
+{% set version = "2.0.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c
+  sha256: 1de1db30d010ff1af14a009224ec49ab2329ad2cde454c8a708130642d579c42
 
 build:
   noarch: python
@@ -16,19 +16,24 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.6
     - pip
   run:
-    - python
+    - python >=3.6
+    - dataclasses
 
 test:
+  requires:
+    - pip
   imports:
     - werkzeug
     - werkzeug.debug
+  commands:
+    - pip check
 
 about:
   home: https://palletsprojects.com/p/werkzeug/
-  license: BSD 3-Clause
+  license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.rst
   summary: The comprehensive WSGI web application library.


### PR DESCRIPTION

1. check the upstream

    https://github.com/pallets/werkzeug/blob/main/CHANGES.rst

    there were only bug fixes or updates but no breaking changes mentioned in the changelog

     Fix type annotation for send_file max_age callable. Don't pass pathlib.Path to max_age. :issue:`2119`
     Mark top-level names as exported so type checking understands imports in user projects. :issue:`2122`
     Fix some types that weren't available in Python 3.6.0. :issue:`2123`
     cached_property is generic over its return type, properties decorated with it report the correct type. :issue:`2113`
     Fix multipart parsing bug when boundary contains special regex characters. :issue:`2125`
     Type checking understands that calling headers.get with a string default will always return a string. :issue:`2128`
     If HTTPException.description is not a string, get_description will convert it to a string. :issue:`2115`

2. the license was checked
3. check pinnings 
    https://github.com/pallets/werkzeug/blob/main/setup.cfg
    python 3.6 and up are specified on the recipe
4. verify the dev_url
5. verivy the doc_url
6. verify that pip is checked
7. verify the test section
8. additional research

    there were no open issues in conda forge
    https://github.com/conda-forge/werkzeug-feedstock/issues

9. additional tests

 the following command was used for testing `conda-build werkzeug-feedstock --test`
 the result was the following `All tests passed`

  Based on our results we can conclude that it is safe to update to version 2.0.1 
