### PR TITLE
Update to 2.0.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,8 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python >=3.6
     - dataclasses

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "Werkzeug" %}
-{% set version = "2.0.1" %}
+{% set version = "2.0.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,16 +7,17 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 1de1db30d010ff1af14a009224ec49ab2329ad2cde454c8a708130642d579c42
+  sha256: aa2bb6fc8dee8d6c504c0ac1e7f5f7dc5810a9903e793b6f715a9f015bdadb9a
 
 build:
+  skip: True  # [py<36]
   noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
   run:
     - python >=3.6
@@ -25,6 +26,7 @@ requirements:
 test:
   requires:
     - pip
+    - python <3.10
   imports:
     - werkzeug
     - werkzeug.debug


### PR DESCRIPTION
Category:  anaconda | subcategory:  dependency | pkg_type:  python
Popularity:  3587407 downloads -  werkzeug  2.0.1  The comprehensive WSGI web application library.
  license: BSD-3-Clause
Release date:  Oct 6, 2021
Bug Tracker: new open issues https://github.com/pallets/werkzeug/issues
Upstream license: https://github.com/pallets/werkzeug/blob/2.0.2/LICENSE.rst
Upstream Changelog: https://github.com/pallets/werkzeug/blob/main/CHANGES.rst
Upstream setup.cfg:  https://github.com/pallets/werkzeug/blob/2.0.2/setup.cfg
Upstream setup.py:  https://github.com/pallets/werkzeug/blob/2.0.2/setup.py

The package werkzeug is mentioned inside the packages:
airflow | connexion | flask | flask-appbuilder | flask-caching | flask-jwt-extended | flask-restx | flask-wtf | moto | pytest-localserver | sendgrid | tensorboard | tranquilizer


Actions:
1. Fix python in the host section
2. Add missing packages: `setuptools`, `wheel`
2. Add `skip py<36`
3. Fix `python <3.10` in test/requires

Result:
- all-succeeded