### PR TITLE
werkzeug 2.0.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,6 @@ source:
   sha256: b863f8ff057c522164b6067c9e28b041161b4be5ba4d0daceeaa50a163822d3c
 
 build:
-  skip: True  # [py<36]
   noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "Werkzeug" %}
-{% set version = "2.0.2" %}
+{% set version = "2.0.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: aa2bb6fc8dee8d6c504c0ac1e7f5f7dc5810a9903e793b6f715a9f015bdadb9a
+  sha256: b863f8ff057c522164b6067c9e28b041161b4be5ba4d0daceeaa50a163822d3c
 
 build:
   skip: True  # [py<36]
@@ -28,7 +28,6 @@ requirements:
 test:
   requires:
     - pip
-    - python <3.10
   imports:
     - werkzeug
     - werkzeug.debug


### PR DESCRIPTION
Bug Tracker: new open issues https://github.com/pallets/werkzeug/issues
Upstream license: https://github.com/pallets/werkzeug/blob/2.0.3/LICENSE.rst
Upstream Changelog: https://github.com/pallets/werkzeug/blob/main/CHANGES.rst
Upstream setup.cfg:  https://github.com/pallets/werkzeug/blob/2.0.3/setup.cfg
Upstream setup.py:  https://github.com/pallets/werkzeug/blob/2.0.3/setup.py

The package werkzeug is mentioned inside the packages:
airflow | connexion | flask | flask-appbuilder | flask-caching | flask-jwt-extended | flask-restx | flask-wtf | moto | pytest-localserver | sendgrid | tensorboard | tranquilizer

Actions:
1. Remove `python <3.10` in test/requires

Result:
- all-succeeded

