### PR TITLE
werkzeug 2.2.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "Werkzeug" %}
-{% set version = "2.0.3" %}
+{% set version = "2.2.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: b863f8ff057c522164b6067c9e28b041161b4be5ba4d0daceeaa50a163822d3c
+  sha256: 7ea2d48322cc7c0f8b3a215ed73eabd7b5d75d0b50e31ab006286ccff9e00b8f
 
 build:
-  noarch: python
   number: 0
+  skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -21,8 +21,8 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.6
-    - dataclasses
+    - python
+    - markupsafe >=2.1.1
 
 test:
   requires:
@@ -40,7 +40,34 @@ about:
   license_file: LICENSE.rst
   summary: The comprehensive WSGI web application library.
   description: |
-    Werkzeug is a WSGI utility library for Python. It's widely used and BSD licensed.
+    **_werkzeug_** German noun: "tool". Etymology: *werk* ("work"), *zeug* ("stuff")
+    Werkzeug is a comprehensive [WSGI](https://wsgi.readthedocs.io/en/latest/) web application library. It began as
+    a simple collection of various utilities for WSGI applications and has
+    become one of the most advanced WSGI utility libraries.
+    It includes:
+      -   An interactive debugger that allows inspecting stack traces and
+          source code in the browser with an interactive interpreter for any
+          frame in the stack.
+      -   A full-featured request object with objects to interact with
+          headers, query args, form data, files, and cookies.
+      -   A response object that can wrap other WSGI applications and handle
+          streaming data.
+      -   A routing system for matching URLs to endpoints and generating URLs
+          for endpoints, with an extensible system for capturing variables
+          from URLs.
+      -   HTTP utilities to handle entity tags, cache control, dates, user
+          agents, cookies, files, and more.
+      -   A threaded WSGI server for use while developing applications
+          locally.
+      -   A test client for simulating HTTP requests during testing without
+          requiring running a server.
+    Werkzeug doesn't enforce any dependencies. It is up to the developer to
+    choose a template engine, database adapter, and even how to handle
+    requests. It can be used to build all sorts of end user applications
+    such as blogs, wikis, or bulletin boards.
+    [Flask](https://www.palletsprojects.com/p/flask/) wraps Werkzeug, using it to handle the details of WSGI while
+    providing more structure and patterns for defining powerful
+    applications. It's widely used and BSD licensed.
   doc_url: https://werkzeug.palletsprojects.com/
   dev_url: https://github.com/pallets/werkzeug
 


### PR DESCRIPTION
Addressing CVE-2022-29361, see also https://github.com/pallets/werkzeug/issues/2431#issuecomment-1154622338

Bug Tracker: new open issues https://github.com/pallets/werkzeug/issues
Upstream license: https://github.com/pallets/werkzeug/blob/2.2.2/LICENSE.rst
Upstream Changelog: https://github.com/pallets/werkzeug/blob/main/CHANGES.rst
Upstream setup.cfg:  https://github.com/pallets/werkzeug/blob/2.2.2/setup.cfg
Upstream setup.py:  https://github.com/pallets/werkzeug/blob/2.2.2/setup.py

Actions:

1. Skip `py<37`
2. Remove `noarch`
3. Fix `python`
4. Update run dependencies: add `markupsafe >=2.1.1`, remove `dataclasses`
5. Extend the `description`