### PR TITLE
Update to 2.3.8 and build for Python 3.12

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   skip: True  # [py<38]
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps -v --no-build-isolation
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "Werkzeug" %}
-{% set version = "3.0.1" %}
+{% set version = "2.3.8" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name|lower }}-{{ version }}.tar.gz
-  sha256: 507e811ecea72b18a404947aded4b3390e1db8f826b494d76550ef45bb3b1dcc
+  sha256: 554b257c74bbeb7a0d254160a4f8ffe185243f52a52035060b761ca62d977f03
 
 build:
   skip: True  # [py<38]
@@ -18,10 +18,12 @@ requirements:
   host:
     - python
     - pip
-    - flit-core
+    - flit-core <4
   run:
     - python
     - MarkupSafe >=2.1.1
+  run_constrained:
+    - watchdog >=2.3
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,16 @@
 {% set name = "Werkzeug" %}
-{% set version = "2.2.3" %}
+{% set version = "3.0.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 2e1ccc9417d4da358b9de6f174e3ac094391ea1d4fbef2d667865d819dfd0afe
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name|lower }}-{{ version }}.tar.gz
+  sha256: 507e811ecea72b18a404947aded4b3390e1db8f826b494d76550ef45bb3b1dcc
 
 build:
-  skip: True  # [py<37]
+  skip: True  # [py<38]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
@@ -18,8 +18,7 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
-    - wheel
+    - flit-core
   run:
     - python
     - MarkupSafe >=2.1.1


### PR DESCRIPTION
werkzeug 2.3.8

**Destination channel:** defaults

### Links

- [PKG-3222](https://anaconda.atlassian.net/browse/PKG-3222)
- [Upstream repository](https://github.com/pallets/werkzeug/tree/2.3.8)
- [Upstream changelog/diff](https://github.com/pallets/werkzeug/compare/2.2.3..2.3.8)

### Explanation of changes:

* Update to 2.3.8
* Build with Python 3.12

[PKG-3222]: https://anaconda.atlassian.net/browse/PKG-3222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ