### PR TITLE
Update 3.0.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "Werkzeug" %}
-{% set version = "3.0.3" %}
+{% set version = "3.0.6" %}
 
 package:
   name: {{ name|lower }}
@@ -7,8 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name|lower }}-{{ version }}.tar.gz
-  sha256: 097e5bfda9f0aba8da6b8545146def481d06aa7d3266e7448e2cccf67dd8bd18
-
+  sha256: a8dd59d4de28ca70471a34cba79bed5f7ef2e036a76b3ab0835474246eb41f8d
 build:
   skip: True  # [py<38]
   number: 0
@@ -29,23 +28,12 @@ test:
   imports:
     - werkzeug
     - werkzeug.debug
-  # source_files:
-  #   - tests
   requires:
     - pip
-    # - cryptography
-    # - greenlet
-    # - pytest
-    # - pytest-timeout
-    # - types-setuptools
   commands:
     - pip check
     # 'pytest' fails immediately because packages 'ephemeral_port_reserve' and 'pytest-xprocess' are not available on defaults.
     # Additionally, 'pytest-xprocess' requires 'psutil' on linux-aarch64 and linux-s390x
-    #- pip install ephemeral_port_reserve pytest-xprocess
-    # Skip 'test_basic' and 'test_http_proxy' because of ConnectionRefusedError.
-    # Skip 'test_serving.py' because watchdog >=2.3 isn't available
-    #- pytest -vv -k "not (exclude_patterns or test_basic or test_http_proxy)" --ignore=tests/test_serving.py
 
 about:
   home: https://palletsprojects.com/p/werkzeug/


### PR DESCRIPTION
> ## ☆Werkzeug 3.0.6☆
> [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-6061) 
[Upstream](https://github.com/pallets/werkzeug/tree/3.0.6)
> 
> ### Changes
> * Updated version number and sha256
> * Updated dependencies for `run` and `host` 

