### PR TITLE
werkzeug 3.1.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "Werkzeug" %}
-{% set version = "3.1.3" %}
+{% set version = "3.1.6" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name|lower }}-{{ version }}.tar.gz
-  sha256: 60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746
+  sha256: 210c6bede5a420a913956b4791a7f4d6843a43b6fcee4dfa08a65e93007d0d25
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-12753](https://anaconda.atlassian.net/browse/PKG-12753)
- [Upstream repository](https://github.com/pallets/werkzeug/tree/3.1.6)
- [Upstream changelog/diff](https://github.com/pallets/werkzeug/blob/3.1.6/CHANGES.rst)

### Explanation of changes:

- Bump version number
- to fix [CVE-2026-27199](https://nvd.nist.gov/vuln/detail/CVE-2026-27199)


[PKG-12753]: https://anaconda.atlassian.net/browse/PKG-12753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ